### PR TITLE
Add display option to getAccounts bitcoin app

### DIFF
--- a/packages/ledger-bitcoin/lib/src/ledger_bitcoin_application.dart
+++ b/packages/ledger-bitcoin/lib/src/ledger_bitcoin_application.dart
@@ -36,7 +36,8 @@ class BitcoinLedgerApp {
     this.derivationPath = "m/84'/0'/0'/0/0",
   });
 
-  Future<List<String>> getAccounts({String? accountsDerivationPath}) async {
+  Future<List<String>> getAccounts(
+      {String? accountsDerivationPath, bool display = false}) async {
     final bipPath =
         BIPPath.fromString(accountsDerivationPath ?? derivationPath);
     final masterFingerprint = await getMasterFingerprint();
@@ -48,7 +49,7 @@ class BitcoinLedgerApp {
       accountXPub: accountXPub,
       masterFingerprint: masterFingerprint,
       descrTempl: "wpkh(@0)",
-      display: false,
+      display: display,
     );
     return [addr.toAsciiString()];
   }


### PR DESCRIPTION
This PR exposes the display option for displaying an address using getAccounts on the Ledger device. It is not reqquired and set to false by default to avoid impact on any existing usage.

Displaying an address on the Ledger is an important security feature, as it allows the user to ensure the address they see on their wallet app is controlled by their Ledger device, which is why exposing this option here is important.